### PR TITLE
populate: expect hashes instead of json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ list of toxics.
 
 ## Populate
 
-To populate Toxiproxy with the proxies from `config/toxiproxy.json`:
+To populate Toxiproxy pass the proxy configurations to `Toxiproxy#populate`:
 
 ```ruby
-Toxiproxy.populate("./config/toxiproxy.json")
+Toxiproxy.populate([{
+  name: "mysql_master",
+  listen: "localhost:21212",
+  upstream: "localhost:3306",
+},{
+  name: "mysql_read_only",
+  listen: "localhost:21213",
+  upstream: "localhost:3306",
+})
 ```
 
+This will create the proxies passed, if they don't already exist, in Toxiproxy.
 It's recommended to do this early as early in boot as possible, see the
-[Toxiproxy README](https://github.com/shopify/toxiproxy#Usage).
+[Toxiproxy README](https://github.com/shopify/toxiproxy#Usage). If you have many
+proxies, we recommend storing the Toxiproxy configs in a configuration file.

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -85,13 +85,12 @@ class Toxiproxy
     find_by_name!(query)
   end
 
-  def self.populate(path)
-    proxies = JSON.parse(File.read(path), symbolize_names: true)
-    proxies = proxies.map { |proxy| self.new(proxy) }
+  def self.populate(*proxies)
+    proxies = proxies.first if proxies.first.is_a?(Array)
 
-    proxies.each do |proxy|
-      proxy.create unless find_by_name(proxy.name)
-    end
+    proxies.map { |proxy|
+      self.create(proxy) unless find_by_name(proxy[:name])
+    }.compact
   end
 
   # Set an upstream toxic.

--- a/test/fixtures/toxiproxy.json
+++ b/test/fixtures/toxiproxy.json
@@ -1,7 +1,0 @@
-[
-  {
-    "name": "toxiproxy_test_mysql",
-    "upstream": "localhost:3306",
-    "listen": "localhost:22222"
-  }
-]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,2 @@
-require 'minitest'
 require 'minitest/autorun'
 require_relative "../lib/toxiproxy"

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -263,8 +263,40 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_populate_creates_proxies
-    proxies = Toxiproxy.populate("./test/fixtures/toxiproxy.json")
+  def test_populate_creates_proxies_array
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3306",
+        listen: "localhost:22222",
+      },
+      {
+        name: "test_toxiproxy_populate2",
+        upstream: "localhost:3306",
+        listen: "localhost:22223",
+      },
+    ]
+
+    proxies = Toxiproxy.populate(proxies)
+
+    proxies.each do |proxy|
+      assert_proxy_available(proxy)
+    end
+  end
+
+  def test_populate_creates_proxies_args
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3306",
+        listen: "localhost:22222",
+      },
+      {
+        name: "test_toxiproxy_populate2",
+        upstream: "localhost:3306",
+        listen: "localhost:22223",
+      },
+    ]
+
+    proxies = Toxiproxy.populate(*proxies)
 
     proxies.each do |proxy|
       assert_proxy_available(proxy)


### PR DESCRIPTION
I think this API is more extensible and easy to understand. I'll update the examples in Toxiproxy.

@xthexder @byroot 