### PR TITLE
Check upstream and listen when populating proxies

### DIFF
--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -89,7 +89,12 @@ class Toxiproxy
     proxies = proxies.first if proxies.first.is_a?(Array)
 
     proxies.map { |proxy|
-      self.create(proxy) unless find_by_name(proxy[:name])
+      existing = find_by_name(proxy[:name])
+      if existing && (existing.upstream != proxy.upstream || existing.listen != proxy.listen)
+        existing.destroy
+        existing = false
+      end
+      self.create(proxy) unless existing
     }.compact
   end
 

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -90,7 +90,7 @@ class Toxiproxy
 
     proxies.map { |proxy|
       existing = find_by_name(proxy[:name])
-      if existing && (existing.upstream != proxy.upstream || existing.listen != proxy.listen)
+      if existing && (existing.upstream != proxy[:upstream] || existing.listen != proxy[:listen])
         existing.destroy
         existing = false
       end

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -303,7 +303,7 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_populate_creates_proxies_update
+  def test_populate_creates_proxies_update_listen
     proxies = [{
         name: "test_toxiproxy_populate1",
         upstream: "localhost:3306",
@@ -325,6 +325,29 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     proxies.each do |proxy|
       assert_proxy_available(proxy)
     end
+  end
+
+  def test_populate_creates_proxies_update_upstream
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3306",
+        listen: "localhost:22222",
+      },
+    ]
+
+    proxies = Toxiproxy.populate(proxies)
+
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3307",
+        listen: "localhost:22222",
+      },
+    ]
+
+    proxies2 = Toxiproxy.populate(proxies)
+
+    assert_equal proxies.first[:upstream], proxies2.first.upstream
+    assert_proxy_available(proxies2.first)
   end
 
   private

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -303,6 +303,30 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_populate_creates_proxies_update
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3306",
+        listen: "localhost:22222",
+      },
+    ]
+
+    proxies = Toxiproxy.populate(proxies)
+
+    proxies = [{
+        name: "test_toxiproxy_populate1",
+        upstream: "localhost:3306",
+        listen: "localhost:22223",
+      },
+    ]
+
+    proxies = Toxiproxy.populate(proxies)
+
+    proxies.each do |proxy|
+      assert_proxy_available(proxy)
+    end
+  end
+
   private
 
   def assert_proxy_available(proxy)


### PR DESCRIPTION
@Sirupsen 

Should fix problems with changing ports around without restarting toxiproxy.