### PR TITLE
try to use SingleForwardable to simplify dynamic method delegation logic

### DIFF
--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -1,12 +1,15 @@
 require "json"
 require "uri"
 require "net/http"
+require "forwardable"
 
 require "toxiproxy/collection"
 require "toxiproxy/toxic"
 require "toxiproxy/toxic_collection"
 
 class Toxiproxy
+  extend SingleForwardable
+
   URI = ::URI.parse("http://127.0.0.1:8474")
   VALID_DIRECTIONS = [:upstream, :downstream]
 
@@ -23,16 +26,7 @@ class Toxiproxy
     @enabled  = options[:enabled]
   end
 
-  # Forwardable doesn't support delegating class methods, so we resort to
-  # `define_method` to delegate from Toxiproxy to #all, and from there to the
-  # proxy collection.
-  class << self
-    Collection::METHODS.each do |method|
-      define_method(method) do |*args, &block|
-        self.all.send(method, *args, &block)
-      end
-    end
-  end
+  def_delegator :all, *Collection::METHODS
 
   # Re-enables all proxies and disables all toxics.
   def self.reset

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -26,7 +26,7 @@ class Toxiproxy
     @enabled  = options[:enabled]
   end
 
-  def_delegator :all, *Collection::METHODS
+  def_delegators :all, *Collection::METHODS
 
   # Re-enables all proxies and disables all toxics.
   def self.reset

--- a/lib/toxiproxy/collection.rb
+++ b/lib/toxiproxy/collection.rb
@@ -1,5 +1,3 @@
-require "forwardable"
-
 class Toxiproxy
   # ProxyCollection represents a set of proxies. This allows to easily perform
   # actions on every proxy in the collection.


### PR DESCRIPTION
at first I wanted to use `define_singleton_method`, but decided to take a look into forwardable.rb file, it was interesting:
```
irb
>> require 'forwardable'
=> true
>> Forwardable.method(:debug).source_location
=> ["/Users/ipoval/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/forwardable.rb", 121]

sed -n '204,240p' /Users/ipoval/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/forwardable.rb

# SingleForwardable can be used to setup delegation at the object level as well.
#
#    printer = String.new
#    printer.extend SingleForwardable        # prepare object for delegation
#    printer.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
#    printer.puts "Howdy!"
#
# Also, SingleForwardable can be used to set up delegation for a Class or Module.
#
#   class Implementation
#     def self.service
#       puts "serviced!"
#     end
#   end
#
#   module Facade
#     extend SingleForwardable
#     def_delegator :Implementation, :service
#   end
#
#   Facade.service #=> serviced!
#
```