### PR TITLE
Upgrade for compatibility with Toxiproxy 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to simulate that your cache server is slow at incoming network
 upstream:
 
 ```ruby
-Toxiproxy[:cache].toxic(:latency, latency: 1000).apply do
+Toxiproxy[:cache].upstream(:latency, latency: 1000).apply do
   Cache.get(:omg) # will take at least a second
 end
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For example, to simulate 1000ms latency on a database server you can use the
 list of all toxics):
 
 ```ruby
-Toxiproxy[:mysql_master].downstream(:latency, latency: 1000).apply do
+Toxiproxy[:mysql_master].toxic(:latency, latency: 1000).apply do
   Shop.first # this took at least 1s
 end
 ```
@@ -55,12 +55,13 @@ If you want to simulate that your cache server is slow at incoming network
 upstream:
 
 ```ruby
-Toxiproxy[:cache].upstream(:latency, latency: 1000).apply do
+Toxiproxy[:cache].toxic(:latency, latency: 1000).apply do
   Cache.get(:omg) # will take at least a second
 end
 ```
 
-You can apply many toxics to many connections:
+By default the toxic is applied to the downstream connection, you can be
+explicit and chain them:
 
 ```ruby
 Toxiproxy[/redis/].upstream(:slow_close, delay: 100).downstream(:latency, jitter: 300).apply do
@@ -90,4 +91,9 @@ Toxiproxy.populate([{
 This will create the proxies passed, or replace the proxies if they already exist in Toxiproxy.
 It's recommended to do this early as early in boot as possible, see the
 [Toxiproxy README](https://github.com/shopify/toxiproxy#Usage). If you have many
-proxies, we recommend storing the Toxiproxy configs in a configuration file.
+proxies, we recommend storing the Toxiproxy configs in a configuration file and
+deserializing it into `Toxiproxy.populate`.
+
+If you're doing this in Rails, you may have to do this in `config/boot.rb` (as
+early in boot as possible) as older versions of `ActiveRecord` establish a
+database connection as soon as it's loaded.

--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 
-VERSION='21a264cc75549c3ae837b606eb6e17ea'
+VERSION='v2.0rc1'
 TOXIPROXY_LOG_DIR=${CIRCLE_ARTIFACTS:-'/tmp'}
 
 echo "[start toxiproxy]"
-curl --silent http://shopify-vagrant.s3.amazonaws.com/toxiproxy/toxiproxy-$VERSION -o ./bin/toxiproxy
-chmod +x ./bin/toxiproxy
-nohup bash -c "./bin/toxiproxy > ${TOXIPROXY_LOG_DIR}/toxiproxy.log 2>&1 &"
+curl --silent https://github.com/Shopify/toxiproxy/releases/download/$VERSION/toxiproxy-server-linux-amd64 -o ./bin/toxiproxy-server
+chmod +x ./bin/toxiproxy-server
+nohup bash -c "./bin/toxiproxy-server > ${TOXIPROXY_LOG_DIR}/toxiproxy.log 2>&1 &"

--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION='v2.0rc1'
+VERSION='v2.0.0rc1'
 TOXIPROXY_LOG_DIR=${CIRCLE_ARTIFACTS:-'/tmp'}
 
 echo "[start toxiproxy]"

--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -4,6 +4,6 @@ VERSION='v2.0.0rc2'
 TOXIPROXY_LOG_DIR=${CIRCLE_ARTIFACTS:-'/tmp'}
 
 echo "[start toxiproxy]"
-curl --silent https://github.com/Shopify/toxiproxy/releases/download/$VERSION/toxiproxy-server-linux-amd64 -o ./bin/toxiproxy-server
+curl --silent -L https://github.com/Shopify/toxiproxy/releases/download/$VERSION/toxiproxy-server-linux-amd64 -o ./bin/toxiproxy-server
 chmod +x ./bin/toxiproxy-server
 nohup bash -c "./bin/toxiproxy-server > ${TOXIPROXY_LOG_DIR}/toxiproxy.log 2>&1 &"

--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION='v2.0.0rc1'
+VERSION='v2.0.0rc2'
 TOXIPROXY_LOG_DIR=${CIRCLE_ARTIFACTS:-'/tmp'}
 
 echo "[start toxiproxy]"

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -129,6 +129,7 @@ class Toxiproxy
     collection
   end
   alias_method :toxic, :downstream
+  alias_method :toxicate, :downstream
 
   # Simulates the endpoint is down, by closing the connection and no
   # longer accepting connections. This is useful to simulate critical system

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -36,6 +36,15 @@ class Toxiproxy
     self
   end
 
+  def self.version
+    return false unless running?
+
+    request = Net::HTTP::Get.new("/version")
+    response = http.request(request)
+    assert_response(response)
+    response.body
+  end
+
   # Returns a collection of all currently active Toxiproxies.
   def self.all
     request = Net::HTTP::Get.new("/proxies")

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -30,7 +30,7 @@ class Toxiproxy
 
   # Re-enables all proxies and disables all toxics.
   def self.reset
-    request = Net::HTTP::Get.new("/reset")
+    request = Net::HTTP::Post.new("/reset")
     response = http.request(request)
     assert_response(response)
     self
@@ -191,20 +191,20 @@ class Toxiproxy
     self
   end
 
-  # Returns a collection of the current toxics for a direction.
+  # Returns an array of the current toxics for a direction.
   def toxics
     request = Net::HTTP::Get.new("/proxies/#{name}/toxics")
     response = http.request(request)
     assert_response(response)
 
-    JSON.parse(response.body).map { |name, attrs|
+    JSON.parse(response.body).map { |attrs|
       Toxic.new(
         type: attrs['type'],
         name: attrs['name'],
         proxy: self,
         stream: attrs['stream'],
         toxicity: attrs['toxicity'],
-        attributes: attrs,
+        attributes: attrs['attributes'],
       )
     }
   end

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -3,9 +3,9 @@ require "uri"
 require "net/http"
 require "forwardable"
 
-require "toxiproxy/collection"
 require "toxiproxy/toxic"
 require "toxiproxy/toxic_collection"
+require "toxiproxy/proxy_collection"
 
 class Toxiproxy
   extend SingleForwardable
@@ -26,7 +26,7 @@ class Toxiproxy
     @enabled  = options[:enabled]
   end
 
-  def_delegators :all, *Collection::METHODS
+  def_delegators :all, *ProxyCollection::METHODS
 
   # Re-enables all proxies and disables all toxics.
   def self.reset
@@ -51,7 +51,7 @@ class Toxiproxy
       })
     }
 
-    Collection.new(proxies)
+    ProxyCollection.new(proxies)
   end
 
   # Sets the toxiproxy host to use.
@@ -105,20 +105,21 @@ class Toxiproxy
   end
 
   # Set an upstream toxic.
-  def upstream(toxic = nil, attrs = {})
-    return @upstream unless toxic
+  def upstream(type = nil, attrs = {})
+    return @upstream unless type # also alias for the upstream endpoint
 
     collection = ToxicCollection.new([self])
-    collection.upstream(toxic, attrs)
+    collection.upstream(type, attrs)
     collection
   end
 
   # Set a downstream toxic.
-  def downstream(toxic, attrs = {})
+  def downstream(type, attrs = {})
     collection = ToxicCollection.new([self])
-    collection.downstream(toxic, attrs)
+    collection.downstream(type, attrs)
     collection
   end
+  alias_method :toxic, :downstream
 
   # Simulates the endpoint is down, by closing the connection and no
   # longer accepting connections. This is useful to simulate critical system
@@ -181,25 +182,21 @@ class Toxiproxy
   end
 
   # Returns a collection of the current toxics for a direction.
-  def toxics(direction)
-    unless VALID_DIRECTIONS.include?(direction.to_sym)
-      raise InvalidToxic, "Toxic direction must be one of: [#{VALID_DIRECTIONS.join(', ')}], got: #{direction}"
-    end
-
-    request = Net::HTTP::Get.new("/proxies/#{name}/#{direction}/toxics")
+  def toxics
+    request = Net::HTTP::Get.new("/proxies/#{name}/toxics")
     response = http.request(request)
     assert_response(response)
 
-    toxics = JSON.parse(response.body).map { |name, attrs|
-      Toxic.new({
-        name: name,
+    JSON.parse(response.body).map { |name, attrs|
+      Toxic.new(
+        type: attrs['type'],
+        name: attrs['name'],
         proxy: self,
-        direction: direction,
-        attrs: attrs
-      })
+        stream: attrs['stream'],
+        toxicity: attrs['toxicity'],
+        attributes: attrs,
+      )
     }
-
-    toxics
   end
 
   private

--- a/lib/toxiproxy/proxy_collection.rb
+++ b/lib/toxiproxy/proxy_collection.rb
@@ -45,6 +45,8 @@ class Toxiproxy
       toxics.downstream(toxic, attrs)
       toxics
     end
+    alias_method :toxicate, :downstream
+    alias_method :toxic, :downstream
 
     def disable
       @collection.each(&:disable)

--- a/lib/toxiproxy/proxy_collection.rb
+++ b/lib/toxiproxy/proxy_collection.rb
@@ -7,7 +7,7 @@ class Toxiproxy
   # Collection instead of an Array (see MRI). Instead, we delegate methods where
   # it doesn't matter and only allow the filtering methods that really make
   # sense on a proxy collection.
-  class Collection
+  class ProxyCollection
     extend Forwardable
 
     DELEGATED_METHODS = [:length, :size, :count, :find, :each, :map]
@@ -46,12 +46,10 @@ class Toxiproxy
       toxics
     end
 
-    # Disables all proxies in the collection.
     def disable
       @collection.each(&:disable)
     end
 
-    # Enables all proxies in the collection.
     def enable
       @collection.each(&:enable)
     end

--- a/lib/toxiproxy/toxic.rb
+++ b/lib/toxiproxy/toxic.rb
@@ -20,7 +20,9 @@ class Toxiproxy
       response = Toxiproxy.http.request(request)
       Toxiproxy.assert_response(response)
 
-      @attrs = JSON.parse(response.body)
+      json = JSON.parse(response.body)
+      @attributes = json['attributes']
+      @toxicity = json['toxicity']
 
       self
     end
@@ -38,7 +40,8 @@ class Toxiproxy
         type: type,
         stream: stream,
         toxicity: toxicity,
-      }.merge(attributes).to_json
+        attributes: attributes,
+      }.to_json
     end
   end
 end

--- a/lib/toxiproxy/toxic.rb
+++ b/lib/toxiproxy/toxic.rb
@@ -3,13 +3,14 @@ class Toxiproxy
     attr_reader :name, :type, :attributes, :stream, :proxy
     attr_accessor :attributes, :toxicity
 
-    def initialize(type:, name: nil, stream: 'downstream', toxicity: 1.0, proxy: nil, attributes: {})
-      @name = name || "#{type}_#{stream}"
-      @type = type
-      @attributes = attributes
-      @proxy = proxy
-      @stream = stream
-      @toxicity = toxicity
+    def initialize(attrs)
+      raise "Toxic type is required" unless attrs[:type]
+      @type = attrs[:type]
+      @stream = attrs[:stream] || 'downstream'
+      @name = attrs[:name] || "#{@type}_#{@stream}"
+      @proxy = attrs[:proxy]
+      @toxicity = attrs[:toxicity] || 1.0
+      @attributes = attrs[:attributes] || {}
     end
 
     def save

--- a/lib/toxiproxy/toxic_collection.rb
+++ b/lib/toxiproxy/toxic_collection.rb
@@ -13,31 +13,35 @@ class Toxiproxy
     end
 
     def apply(&block)
-      @toxics.each(&:enable)
+      @toxics.each(&:save)
       yield
     ensure
-      @toxics.each(&:disable)
+      @toxics.each(&:destroy)
     end
 
-    def upstream(toxic_name, attrs = {})
+    def upstream(type, attrs = {})
       proxies.each do |proxy|
         toxics << Toxic.new(
-          name: toxic_name,
+          name: attrs.delete('name') || attrs.delete(:name),
+          type: type,
           proxy: proxy,
-          direction: :upstream,
-          attrs: attrs
+          stream: :upstream,
+          toxicity: attrs.delete('toxicitiy') || attrs.delete(:toxicity),
+          attributes: attrs
         )
       end
       self
     end
 
-    def downstream(toxic_name, attrs = {})
+    def downstream(type, attrs = {})
       proxies.each do |proxy|
         toxics << Toxic.new(
-          name: toxic_name,
+          name: attrs.delete('name') || attrs.delete(:name),
+          type: type,
           proxy: proxy,
-          direction: :downstream,
-          attrs: attrs
+          stream: :downstream,
+          toxicity: attrs.delete('toxicitiy') || attrs.delete(:toxicity),
+          attributes: attrs
         )
       end
       self

--- a/lib/toxiproxy/toxic_collection.rb
+++ b/lib/toxiproxy/toxic_collection.rb
@@ -13,10 +13,18 @@ class Toxiproxy
     end
 
     def apply(&block)
-      @toxics.each(&:save)
-      yield
-    ensure
-      @toxics.each(&:destroy)
+      names = toxics.group_by { |t| [t.name, t.proxy.name] }
+      dups  = names.values.select { |toxics| toxics.length > 1 }
+      if !dups.empty?
+        raise ArgumentError, "There are two toxics with the name #{dups.first[0]} for proxy #{dups.first[1]}, please override the default name (<type>_<direction>)"
+      end
+
+      begin
+        @toxics.each(&:save)
+        yield
+      ensure
+        @toxics.each(&:destroy)
+      end
     end
 
     def upstream(type, attrs = {})
@@ -46,5 +54,7 @@ class Toxiproxy
       end
       self
     end
+    alias_method :toxic, :downstream
+    alias_method :toxicate, :downstream
   end
 end

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -384,6 +384,10 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     assert_equal true, Toxiproxy.running?
   end
 
+  def test_version
+    assert_instance_of String, Toxiproxy.version
+  end
+
   private
 
   def assert_proxy_available(proxy)

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -420,7 +420,7 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     with_tcpserver(receive: true) do |port|
       proxy = Toxiproxy.create(upstream: "localhost:#{port}", name: "test_rubby_server")
 
-      assert_raises Toxiproxy::NotFound do
+      assert_raises Toxiproxy::InvalidToxic do
         Toxiproxy::Toxic.new(type: 'latency', attributes: { latency: 123 }, proxy: proxy, stream: 'lolstream').save
       end
     end

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -63,8 +63,8 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
       assert_equal 123, latency.attributes['latency']
 
       latency.destroy
-      assert_predicate proxy.toxics, :empty?
 
+      assert proxy.toxics.empty?
       assert_equal listen_addr, proxy.listen
     end
   end
@@ -82,7 +82,7 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
       Toxiproxy.reset
       assert_proxy_available proxy
 
-      assert_predicate proxy.toxics, :empty?
+      assert proxy.toxics.empty?
       assert_equal listen_addr, proxy.listen
     end
   end

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -388,6 +388,44 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     assert_instance_of String, Toxiproxy.version
   end
 
+  def test_multiple_of_same_toxic_type
+    with_tcpserver(receive: true) do |port|
+      proxy = Toxiproxy.create(upstream: "localhost:#{port}", name: "test_proxy")
+      proxy.toxic(:latency, latency: 100).toxic(:latency, latency: 100, name: "second_latency_downstream").apply do
+        before = Time.now
+
+        socket = connect_to_proxy(proxy)
+        socket.write("omg\n")
+        socket.flush
+        socket.gets
+
+        passed = Time.now - before
+
+        assert_in_delta passed, 0.200, 0.01
+      end
+    end
+  end
+
+  def test_multiple_of_same_toxic_type_with_same_name
+    with_tcpserver(receive: true) do |port|
+      proxy = Toxiproxy.create(upstream: "localhost:#{port}", name: "test_proxy")
+
+      assert_raises ArgumentError do
+        proxy.toxic(:latency, latency: 100).toxic(:latency, latency: 100).apply { }
+      end
+    end
+  end
+
+  def test_invalid_direction
+    with_tcpserver(receive: true) do |port|
+      proxy = Toxiproxy.create(upstream: "localhost:#{port}", name: "test_rubby_server")
+
+      assert_raises Toxiproxy::NotFound do
+        Toxiproxy::Toxic.new(type: 'latency', attributes: { latency: 123 }, proxy: proxy, stream: 'lolstream').save
+      end
+    end
+  end
+
   private
 
   def assert_proxy_available(proxy)


### PR DESCRIPTION
This makes the Ruby gem compatible with v2.0.0rc1 (https://github.com/Shopify/toxiproxy/pull/83).

@byroot @fw42 @xthexder 