### PR TITLE
Allow specifying a custom host

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ documentation](https://github.com/shopify/toxiproxy)
 
 ## Usage
 
-The Ruby client communicates with the Toxiproxy daemon via HTTP.
+The Ruby client communicates with the Toxiproxy daemon via HTTP. By default it
+connects to `http://127.0.0.1:8474`, but you can point to any host:
+
+```ruby
+Toxiproxy.host = 'http://toxiproxy.local:5665'
+```
 
 For example, to simulate 1000ms latency on a database server you can use the
 `latency` toxic with the `latency` argument (see the Toxiproxy project for a

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -10,7 +10,7 @@ require "toxiproxy/toxic_collection"
 class Toxiproxy
   extend SingleForwardable
 
-  URI = ::URI.parse("http://127.0.0.1:8474")
+  DEFAULT_URI = 'http://127.0.0.1:8474'
   VALID_DIRECTIONS = [:upstream, :downstream]
 
   class NotFound < StandardError; end
@@ -54,6 +54,11 @@ class Toxiproxy
     Collection.new(proxies)
   end
 
+  # Sets the toxiproxy host to use.
+  def self.host=(host)
+    @uri = host.is_a?(::URI) ? host : ::URI.parse(host)
+  end
+
   # Convenience method to create a proxy.
   def self.create(options)
     self.new(options).create
@@ -93,7 +98,7 @@ class Toxiproxy
   end
 
   def self.running?
-    TCPSocket.new(URI.host, URI.port).close
+    TCPSocket.new(uri.host, uri.port).close
     true
   rescue Errno::ECONNREFUSED, Errno::ECONNRESET
     false
@@ -199,8 +204,12 @@ class Toxiproxy
 
   private
 
+  def self.uri
+    @uri ||= ::URI.parse(DEFAULT_URI)
+  end
+
   def self.http
-    @http ||= Net::HTTP.new(URI.host, URI.port)
+    @http ||= Net::HTTP.new(uri.host, uri.port)
   end
 
   def http

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -24,6 +24,13 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     assert_equal "test_mysql_master", proxy.name
   end
 
+  def test_proxy_not_running_with_bad_host
+    Toxiproxy.host = 'http://0.0.0.0:12345'
+    assert !Toxiproxy.running?, 'toxiproxy should not be running'
+  ensure
+    Toxiproxy.host = Toxiproxy::DEFAULT_URI
+  end
+
   def test_enable_and_disable_proxy
     with_tcpserver do |port|
       proxy = Toxiproxy.create(upstream: "localhost:#{port}", name: "test_rubby_server")


### PR DESCRIPTION
By default, it will read the host from the `TOXIPROXY_HOST` env var, or `127.0.0.1:8474` if that env var is not set. I opted to including the env var configuration since we'll quite possibly be using it in one of our own projects, but it just seemed like a useful thing in general. You can also set it programmatically via `Toxiproxy.host = <host>`. All in all this is essentially a no-op change, unless someone has been setting a `TOXIPROXY_HOST` environment var.

I opted to allow using `nil` as the host, which will reset it to the defaults (env var / default) to allow me to more easily `rake test` under various scenarios, but I can unset this behaviour.

Resolves https://github.com/Shopify/toxiproxy-ruby/issues/17

r: @xthexder @Sirupsen 