### PR TITLE
Update toxiproxy server to 2.0.0

### DIFF
--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -1,9 +1,17 @@
 #!/bin/bash -e
 
-VERSION='v2.0.0rc2'
+VERSION='v2.0.0'
 TOXIPROXY_LOG_DIR=${CIRCLE_ARTIFACTS:-'/tmp'}
 
+if [[ "$OSTYPE" == "linux"* ]]; then
+    DOWNLOAD_TYPE="linux-amd64"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    DOWNLOAD_TYPE="darwin-amd64"
+fi
+
+echo "[dowload toxiproxy for $DOWNLOAD_TYPE]"
+curl --silent -L https://github.com/Shopify/toxiproxy/releases/download/$VERSION/toxiproxy-server-$DOWNLOAD_TYPE -o ./bin/toxiproxy-server
+
 echo "[start toxiproxy]"
-curl --silent -L https://github.com/Shopify/toxiproxy/releases/download/$VERSION/toxiproxy-server-linux-amd64 -o ./bin/toxiproxy-server
 chmod +x ./bin/toxiproxy-server
 nohup bash -c "./bin/toxiproxy-server > ${TOXIPROXY_LOG_DIR}/toxiproxy.log 2>&1 &"


### PR DESCRIPTION
- Using a new version of Toxiproxy server
- Detecting the running OS type to download the right binary to run the tests (tested on Ubuntu and on my OSX).