### PR TITLE
whitelist toxiproxy when using webmock

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,3 +5,7 @@ dependencies:
 test:
   override:
     - bundle exec rake test
+
+machine:
+  ruby:
+    version: 2.4.0

--- a/lib/toxiproxy/toxic.rb
+++ b/lib/toxiproxy/toxic.rb
@@ -18,7 +18,7 @@ class Toxiproxy
 
       request.body = as_json
 
-      response = Toxiproxy.http.request(request)
+      response = Toxiproxy.http_request(request)
       Toxiproxy.assert_response(response)
 
       json = JSON.parse(response.body)
@@ -30,7 +30,7 @@ class Toxiproxy
 
     def destroy
       request = Net::HTTP::Delete.new("/proxies/#{proxy.name}/toxics/#{name}")
-      response = Toxiproxy.http.request(request)
+      response = Toxiproxy.http_request(request)
       Toxiproxy.assert_response(response)
       self
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,4 @@
 require 'minitest/autorun'
 require_relative "../lib/toxiproxy"
+require 'webmock/minitest'
+WebMock.disable!

--- a/toxiproxy.gemspec
+++ b/toxiproxy.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
Currently, `toxiproxy-ruby` does not play well with the `webmock` gem. When the `WebMock.disable_net_connect!` option is specified, `webmock` throws exceptions for all real network HTTP calls including those made by `toxiproxy-ruby` to the `toxiproxy` server.

Rather than forcing a user to whitelist the `toxiproxy` host before every test that uses `toxiproxy-ruby`, this PR ensures `toxiproxy` is whitelisted by `webmock` before every HTTP request to the `toxiproxy` server.

### How is this accomplished?
Before every HTTP request, `toxiproxy-ruby` checks if `WebMock` is defined. If it is, it attempts to add the `toxiproxy` host to the `WebMock::Config.instance.allow` whitelist.

### How do we avoid leaking state?
By only appending to `WebMock::Config.instance.allow`, we avoid overwriting any state that a test suite has already configured. The only state we leak is leaving `toxiproxy` permanently in the whitelist. I don't think this is an issue.

### Why don't we have similar logic for other HTTP mocking libraries?
We use `webmock` and it seems to be the most popular solution publicly. We can add support for other gems if our users report having issues. I think it would be premature to add support for other gems.

### Requiring Ruby 2.0.0
Adding `webmock` as a dependency requires a Ruby version of `2.0.0` or greater. I added what I believe is the correct configuration to our `gemspec` and to our `circle.yml`. I would love for someone to confirm that I've configured this properly.

@sirupsen @daniellaniyo @masom 