### PR TITLE
version: bump to 1.0.2

### DIFF
--- a/lib/toxiproxy/version.rb
+++ b/lib/toxiproxy/version.rb
@@ -1,3 +1,3 @@
 class Toxiproxy
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Shipit is having trouble version bumping to 1.0.1. Let's try 1.0.2.