### PR TITLE
fixes warning method redefined; discarding old attributes

### DIFF
--- a/lib/toxiproxy/toxic.rb
+++ b/lib/toxiproxy/toxic.rb
@@ -1,6 +1,6 @@
 class Toxiproxy
   class Toxic
-    attr_reader :name, :type, :attributes, :stream, :proxy
+    attr_reader :name, :type, :stream, :proxy
     attr_accessor :attributes, :toxicity
 
     def initialize(attrs)


### PR DESCRIPTION
The getter for `attributes` is being defined twice once with `attr_reader` and again with `attr_accessor`. That leads to warning as following:
```
/Users/elvinefendi/.gem/ruby/2.4.3/bundler/gems/toxiproxy-ruby-a44448f64ad3/lib/toxiproxy/toxic.rb:4: warning: method redefined; discarding old attributes
```

The PR fixes that by removing the first one.