### PR TITLE
Toxiproxy does not handle adding endpoints to Webmock exception list properly

### DIFF
--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -229,7 +229,9 @@ class Toxiproxy
     endpoint = "#{uri.host}:#{uri.port}"
     WebMock::Config.instance.allow ||= []
     unless WebMock::Config.instance.allow.include?(endpoint)
-      WebMock::Config.instance.allow << endpoint
+      WebMock.disable_net_connect!(
+        allow: (WebMock::Config.instance.allow.dup << endpoint)
+      )
     end
   end
 

--- a/lib/toxiproxy/version.rb
+++ b/lib/toxiproxy/version.rb
@@ -1,3 +1,3 @@
 class Toxiproxy
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
This PR updates the mechanism by which endpoints are added to the `allow` list for WebMock.