### PR TITLE
Use /populate endpoint for Toxiproxy.populate

### DIFF
--- a/lib/toxiproxy/version.rb
+++ b/lib/toxiproxy/version.rb
@@ -1,3 +1,3 @@
 class Toxiproxy
-  VERSION = "1.0.3"
+  VERSION = "2.0.0"
 end

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -358,26 +358,31 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
   end
 
   def test_populate_creates_proxies_update_upstream
-    proxies = [{
-        name: "test_toxiproxy_populate1",
+    proxy_name = "test_toxiproxy_populate1"
+    proxies_config = [{
+        name: proxy_name,
         upstream: "localhost:3306",
         listen: "localhost:22222",
       },
     ]
 
-    proxies = Toxiproxy.populate(proxies)
+    proxies = Toxiproxy.populate(proxies_config)
 
-    proxies = [{
-        name: "test_toxiproxy_populate1",
+    proxies_config = [{
+        name: proxy_name,
         upstream: "localhost:3307",
         listen: "localhost:22222",
       },
     ]
 
-    proxies2 = Toxiproxy.populate(proxies)
+    proxies2 = Toxiproxy.populate(proxies_config)
 
-    assert_equal proxies.first[:upstream], proxies2.first.upstream
-    assert_proxy_available(proxies2.first)
+    refute_equal proxies.find(name: proxy_name).first.upstream,
+      proxies2.find(name: proxy_name).first.upstream
+
+    proxies2.each do |proxy|
+      assert_proxy_available(proxy)
+    end
   end
 
   def test_running_helper


### PR DESCRIPTION
This PR replaces the existing `Toxiproxy.populate` to use the toxiproxy `/populate` endpoint since the existing logic is not thread-safe in multi-threaded environments. 

One breaking change to note is that toxiproxy's `/populate` assumes the latest passed-in configuration as its source of truth. On the other hand `toxiproxy-ruby` client is now consistent with the golang client behaviour: https://github.com/Shopify/toxiproxy/blob/master/client/client.go#L138 

Since this behaviour constitutes a breaking change + in line with the spirit of SemVer, I've bumped the version to 2.0.0.