### PR TITLE
Invalidate memorized object http on host changes

### DIFF
--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -68,6 +68,8 @@ class Toxiproxy
   # Sets the toxiproxy host to use.
   def self.host=(host)
     @uri = host.is_a?(::URI) ? host : ::URI.parse(host)
+    reset_http_client!
+    @uri
   end
 
   # Convenience method to create a proxy.
@@ -221,6 +223,15 @@ class Toxiproxy
         attributes: attrs['attributes'],
       )
     }
+  end
+
+  def self.reset_http_client!
+    if defined? @http
+      @http.finish() if @http && @http.started?
+      @http = nil
+    end
+
+    @http
   end
 
   private

--- a/test/toxiproxy_test.rb
+++ b/test/toxiproxy_test.rb
@@ -453,6 +453,15 @@ class ToxiproxyTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_invalidate_cache_http_on_host
+    old_value = Toxiproxy.uri
+    assert_equal 8474, Toxiproxy.http.port
+    Toxiproxy.host = "http://127.0.0.1:8475"
+    assert_equal 8475, Toxiproxy.http.port
+  ensure
+    Toxiproxy.host = old_value
+  end
+
   private
 
   def with_webmock_enabled


### PR DESCRIPTION
Currently http is cached and could be never changed.
Make sure there is possible to update toxiproxy client to different
server, invalidate cache for http.