### PR TITLE
Update release pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-vendor/
 .bundle
-Gemfile.lock
 *.gem
+Gemfile.lock
+pkg/
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 gemspec
 
-gem "bundler"
-gem "minitest"
-gem "rake"
-gem "webmock"
+group :test do
+  gem "minitest"
+  gem "rake"
+  gem "webmock"
+end

--- a/scripts/pre_release
+++ b/scripts/pre_release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+tag=$(git tag --contains HEAD | wc -l)
+
+if [ $tag == "0" ] ; then
+  echo "No tag attached!"
+  exit 1
+fi

--- a/shipit.release.yml
+++ b/shipit.release.yml
@@ -1,0 +1,11 @@
+---
+
+dependencies:
+  bundler:
+    without:
+      - test
+
+deploy:
+  max_commits: 1
+  pre:
+    - ./scripts/pre_release

--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,4 +1,0 @@
----
-
-fetch:
-  - fetch-gem-version toxiproxy Shopify/toxiproxy-ruby


### PR DESCRIPTION
Rename shipit pipeline `rubygems` -> `release`.
Block release pipeline if there is no tag exists.
Deliver each commit separately to make sure to not miss a tag.
Skip install test gems during release.

## Post merge steps

- Delete rubygems Shipit pipeline
- Create release Shipit pipeline for master branch