### PR TITLE
Dependabot PRs use version information from incorrect repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Create a RELEASE.md with release instructions.
+  ([#44](https://github.com/Shopify/toxiproxy-ruby/pull/44), @miry)
+- Introduce github actions to validate git tags and yaml.
+  ([#45](https://github.com/Shopify/toxiproxy-ruby/pull/45), @miry)
+- Introduce CHANGELOG.md.
+  ([#47](https://github.com/Shopify/toxiproxy-ruby/pull/47), @miry)
+
+### Changed
+- Update release pipeline to trigger only if a new tag appeared.
+  ([#46](https://github.com/Shopify/toxiproxy-ruby/pull/46), @miry)
+- Add gem metafields `source_code_uri` and `changelog_uri`.
+  ([#47](https://github.com/Shopify/toxiproxy-ruby/pull/47), @miry)
+
+## [2.0.1] - 2022-03-15
+### Changed
+- Test against v3.0 and v3.1 ruby. Drop support of v2.5 ruby.
+  ([#42](https://github.com/Shopify/toxiproxy-ruby/pull/42), @miry)
+- Reset http client on host changes. ([#43](https://github.com/Shopify/toxiproxy-ruby/pull/43), @miry)
+
+[Unreleased]: https://github.com/Shopify/toxiproxy-ruby/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/Shopify/toxiproxy-ruby/compare/v2.0.0...v2.0.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,8 @@ $ git pull origin master
 
 Update version in [`lib/toxiproxy/version.rb`](./lib/toxiproxy/version.rb).
 Check if there is required changes in [`README.md`](./README.md).
+Add line after `## [Unreleased]` in [`CHANGELOG.md`][./CHANGELOG.md] with new version
+and update links to commits compare in the bottom of the document.
 
 ### Run Tests
 
@@ -31,6 +33,7 @@ $ rake build
 ### Create Release Commit and Tag
 
 Commit changes and create a tag. Make sure commit and tag are signed.
+Extract related content from [`CHANGELOG.md`][./CHANGELOG.md] for a tag message.
 
 ```shell
 $ export RELEASE_VERSION=2.x.y

--- a/toxiproxy.gemspec
+++ b/toxiproxy.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "homepage_uri" => "https://github.com/Shopify/toxiproxy",
+    "source_code_uri" => "https://github.com/Shopify/toxiproxy-ruby",
+    "changelog_uri" => "https://github.com/Shopify/toxiproxy-ruby/blob/master/CHANGELOG.md",
     "documentation_uri" => "https://github.com/Shopify/toxiproxy-ruby",
     "allowed_push_host" => "https://rubygems.org"
   }


### PR DESCRIPTION
[The `toxiproxy` gem](https://rubygems.org/gems/toxiproxy) is fed by releases from the `toxiproxy-ruby` repo, but Dependabot gem bump PRs for this gem will link to and source the changelog from https://github.com/Shopify/toxiproxy/ instead, which is confusing and misleading. An example from a private repo: https://github.com/Shopify/pay/pull/14119

This may be caused by [the gemspec file](https://github.com/Shopify/toxiproxy-ruby/blob/master/toxiproxy.gemspec) referring to https://github.com/Shopify/toxiproxy for most fields, including the homepage.

