### PR TITLE
Fix uninitialized instance variable warning

### DIFF
--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -225,13 +225,10 @@ class Toxiproxy
     }
   end
 
+  @http = nil
   def self.reset_http_client!
-    if defined? @http
-      @http.finish() if @http && @http.started?
-      @http = nil
-    end
-
-    @http
+    @http.finish if @http&.started?
+    @http = nil
   end
 
   private


### PR DESCRIPTION
In my projects I tend to turn Ruby warnings into errors, and a warning was introduced in toxiproxy 2.0.1 that fail my test suite: https://github.com/redis-rb/redis-client/runs/8136514077?check_suite_focus=true#step:6:59