### PR TITLE
Updating the refernces from master to main in GH actions and readme and change log link

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -4,9 +4,9 @@ name: Analysis
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: 13 7 * * 6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,8 @@ Ensure your local workstation is configured to be able to
 ### Checkout latest code
 
 ```shell
-$ git checkout master
-$ git pull origin master
+$ git checkout main
+$ git pull origin main
 ```
 
 ### Bump version
@@ -47,7 +47,7 @@ $ git tag -s "v$RELEASE_VERSION"
 On your local machine again, push your commit and tag
 
 ```shell
-$ git push origin master --follow-tags
+$ git push origin main --follow-tags
 ```
 
 ## Verify rubygems release

--- a/toxiproxy.gemspec
+++ b/toxiproxy.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => "https://github.com/Shopify/toxiproxy",
     "source_code_uri" => "https://github.com/Shopify/toxiproxy-ruby",
-    "changelog_uri" => "https://github.com/Shopify/toxiproxy-ruby/blob/master/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/Shopify/toxiproxy-ruby/blob/main/CHANGELOG.md",
     "documentation_uri" => "https://github.com/Shopify/toxiproxy-ruby",
     "allowed_push_host" => "https://rubygems.org",
   }


### PR DESCRIPTION
Resolves #67 
This PR updates the references of master in the GH actions and readme.
Once the default branch for this repo is moved from master to main, these changes are required.

The PR will be merged only after the trunk has migrated.

