### PR TITLE
Revert "Bump github/codeql-action from 2 to 3"

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -55,9 +55,9 @@ jobs:
           fetch-depth: 0
       -
         name: initialize
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v2
         with:
           languages: ruby
       -
         name: codeql analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Reverts Shopify/toxiproxy-ruby#93

Appears to be issues with these github actions.