### PR TITLE
Use PATCH not POST when enable/disabling toxiproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use `PATCH` not `POST` when modifying proxies.
+  ([#186](https://github.com/Shopify/toxiproxy-ruby/pull/186), @brendo)
+- Set HTTP timeout of 5s when communicating with Toxiproxy server.
+  ([#85](https://github.com/Shopify/toxiproxy-ruby/pull/85), @casperisfine)
+
 ## [2.0.2] - 2022-09-02
 ### Fixed
 - Fix uninitialized instance variable warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Use `PATCH` not `POST` when modifying proxies.
+- Use `PATCH` not `POST` when enabling or disabling proxies when Toxiproxy supports `PATCH`.
   ([#186](https://github.com/Shopify/toxiproxy-ruby/pull/186), @brendo)
 - Set HTTP timeout of 5s when communicating with Toxiproxy server.
   ([#85](https://github.com/Shopify/toxiproxy-ruby/pull/85), @casperisfine)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Gem Version](https://badge.fury.io/rb/toxiproxy.svg)](https://badge.fury.io/rb/toxiproxy)
 [![Test](https://github.com/Shopify/toxiproxy-ruby/actions/workflows/test.yml/badge.svg)](https://github.com/Shopify/toxiproxy-ruby/actions/workflows/test.yml)
 
-`toxiproxy-ruby` `>= 1.x` is compatible with the Toxiproxy `2.x` series.
-`toxiproxy-ruby` `0.x` is compatible with the Toxiproxy `1.x` series.
+- `toxiproxy-ruby` `>= 3.x` is compatible with the Toxiproxy `2.6+` series.
+- `toxiproxy-ruby` `>= 1.x` is compatible with the Toxiproxy `2.x` series.
+- `toxiproxy-ruby` `0.x` is compatible with the Toxiproxy `1.x` series.
 
 [Toxiproxy](https://github.com/shopify/toxiproxy) is a proxy to simulate network
 and system conditions. The Ruby API aims to make it simple to write tests that

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/toxiproxy.svg)](https://badge.fury.io/rb/toxiproxy)
 [![Test](https://github.com/Shopify/toxiproxy-ruby/actions/workflows/test.yml/badge.svg)](https://github.com/Shopify/toxiproxy-ruby/actions/workflows/test.yml)
 
-- `toxiproxy-ruby` `>= 3.x` is compatible with the Toxiproxy `2.6+` series.
 - `toxiproxy-ruby` `>= 1.x` is compatible with the Toxiproxy `2.x` series.
 - `toxiproxy-ruby` `0.x` is compatible with the Toxiproxy `1.x` series.
 

--- a/bin/start-toxiproxy.sh
+++ b/bin/start-toxiproxy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION='v2.4.0'
+VERSION='v2.12.0'
 
 if [[ "$OSTYPE" == "linux"* ]]; then
     DOWNLOAD_TYPE="linux-amd64"

--- a/lib/toxiproxy.rb
+++ b/lib/toxiproxy.rb
@@ -212,7 +212,7 @@ class Toxiproxy
 
   # Disables a Toxiproxy. This will drop all active connections and stop the proxy from listening.
   def disable
-    request = Net::HTTP::Post.new("/proxies/#{name}")
+    request = Net::HTTP::Patch.new("/proxies/#{name}")
     request["Content-Type"] = "application/json"
 
     hash = { enabled: false }
@@ -225,7 +225,7 @@ class Toxiproxy
 
   # Enables a Toxiproxy. This will cause the proxy to start listening again.
   def enable
-    request = Net::HTTP::Post.new("/proxies/#{name}")
+    request = Net::HTTP::Patch.new("/proxies/#{name}")
     request["Content-Type"] = "application/json"
 
     hash = { enabled: true }


### PR DESCRIPTION
Calls to `proxies/{name}` are currently going via POST which is triggering log output like:

```
{"level":"warn","request_id":"d2h9e85ctoqc73edkk0g","caller":"api.go:299","time":"2025-08-18T02:59:44Z","message":"ProxyUpdate: HTTP method POST is depercated. Use HTTP PATCH instead."}
```

This log is being emitted from Toxiproxy itself:

https://github.com/Shopify/toxiproxy/blob/6caf93523ef11fe7a546457b8d4114a1a634510e/api.go#L296-L300

To remove the log, this PR changes `Toxiproxy.enable`/`Toxiproxy.disable` to use `PATCH` instead of `POST`.